### PR TITLE
feat: add PR title validation for conventional commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Descripción
+
+Breve descripción de los cambios realizados.
+
+## ⚠️ Verificar Título del PR
+
+**IMPORTANTE**: El título de este PR debe seguir el formato conventional commits:
+- ✅ Formato: `type(scope): description`
+- ✅ Ejemplos válidos: `feat: add user auth`, `fix(api): resolve bug`, `docs: update readme`
+- ❌ NO válido: `Add feature`, `Fix bug`, `Update`
+
+## Tipo de cambio
+
+- [ ] Bug fix (cambio que corrige un problema)
+- [ ] Nueva funcionalidad (cambio que agrega funcionalidad)
+- [ ] Breaking change (cambio que puede romper funcionalidad existente)
+- [ ] Refactoring (cambio de código que no corrige bugs ni agrega funcionalidad)
+- [ ] Documentación
+- [ ] Configuración/CI
+
+## ¿Cómo se ha probado?
+
+- [ ] Tests unitarios
+- [ ] Tests de integración
+- [ ] Pruebas manuales
+- [ ] `python src/manage.py check` pasa sin errores
+- [ ] `ruff check .` pasa sin errores
+
+## Checklist
+
+- [ ] **Mi título de PR sigue el formato conventional commits**
+- [ ] Mi código sigue las convenciones del proyecto (Ruff)
+- [ ] He realizado una self-review de mi código
+- [ ] He comentado mi código en áreas difíciles de entender
+- [ ] He actualizado la documentación si es necesario
+- [ ] Mis cambios no generan nuevas advertencias
+- [ ] He agregado tests que prueban mi funcionalidad
+- [ ] Los tests nuevos y existentes pasan localmente
+
+## Contexto adicional
+
+Agregar cualquier contexto adicional sobre el PR aquí.

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,53 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-pr-title:
+    name: Check PR Title Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure conventional commit types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Require scope to be in parentheses (optional)
+          requireScope: false
+          # Allow custom scopes
+          scopes: |
+            api
+            ui
+            db
+            auth
+            workflow
+            deps
+            config
+            security
+          # Custom subject pattern (optional)
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # Ignore merge commits
+          ignoreLabels: |
+            ignore-semantic-pull-request
+          # Custom error message
+          headerPattern: '^(\w*)(?:\(([^)]*)\))?: (.+)$'
+          headerPatternCorrespondence: type,scope,subject

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,48 @@
+name: PR Title Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR Title Format
+        uses: deepakputhraya/action-pr-title@master
+        with:
+          regex: '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+$'
+          allowed_prefixes: 'feat,fix,docs,style,refactor,perf,test,build,ci,chore,revert'
+          prefix_case_sensitive: false
+          min_length: 10
+          max_length: 120
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR if title is invalid
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ **PR Title Format Error**
+
+              Your PR title doesn't follow the conventional commit format required for semantic-release.
+
+              **Required format:** \`type(scope): description\`
+
+              **Valid types:** feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+
+              **Examples:**
+              - \`feat: add user authentication\`
+              - \`fix(auth): resolve login redirect issue\`
+              - \`docs: update API documentation\`
+              - \`chore(deps): update dependencies\`
+
+              **Current title:** "${context.payload.pull_request.title}"
+
+              Please update your PR title to match the required format.`
+            })

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,8 +33,52 @@ git push origin feat/nombre-de-la-funcionalidad
 
 ### 4. Crear Pull Request
 - Ir a GitHub y crear un PR desde tu rama hacia `main`
+- **IMPORTANTE**: El título del PR debe seguir el formato conventional commits
 - Completar el template de PR con toda la información necesaria
 - Asegurarse de que todos los checks pasen
+
+## Formato de Títulos de PR
+
+Los títulos de Pull Request **DEBEN** seguir el formato conventional commits para que semantic-release funcione correctamente:
+
+### **Formato requerido:**
+```
+type(scope): description
+```
+
+### **Tipos válidos:**
+- `feat` - Nueva funcionalidad
+- `fix` - Corrección de bugs  
+- `docs` - Documentación
+- `style` - Formato/estilo de código
+- `refactor` - Refactoring
+- `perf` - Mejoras de performance
+- `test` - Tests
+- `build` - Sistema de build
+- `ci` - CI/CD
+- `chore` - Tareas de mantenimiento
+- `revert` - Revertir cambios
+
+### **Ejemplos de títulos válidos:**
+- ✅ `feat: add user authentication system`
+- ✅ `fix(auth): resolve login redirect issue` 
+- ✅ `docs: update API documentation`
+- ✅ `chore(deps): update dependencies to latest versions`
+- ✅ `perf: optimize database queries for hunt search`
+
+### **Ejemplos de títulos NO válidos:**
+- ❌ `Add user authentication` (no type)
+- ❌ `feat: Add user authentication` (descripción empieza con mayúscula)
+- ❌ `update docs` (no type, descripción muy corta)
+
+### **Reglas adicionales:**
+- La descripción debe empezar con minúscula
+- Longitud mínima: 10 caracteres
+- Longitud máxima: 120 caracteres
+- El scope es opcional pero recomendado
+
+### **Validación automática:**
+Si el título no cumple el formato, el PR será bloqueado y recibirás un comentario automático con instrucciones para corregirlo.
 
 ## Checks Automáticos
 
@@ -44,24 +88,29 @@ Cada PR ejecuta automáticamente:
 - ✅ Ruff linter (`ruff check .`)
 - ✅ Ruff formatter (`ruff format --check .`)
 - ✅ Django system check (`python src/manage.py check`)
-- ✅ Django deployment check (`python src/manage.py check --deploy`)
 
 ### Django Tests  
 - ✅ Check de migraciones (`makemigrations --check`)
 - ✅ Tests de Django (`python src/manage.py test`)
 - ✅ Verificación de migraciones faltantes
 
+### PR Title Validation
+- ✅ Formato conventional commits
+- ✅ Tipos válidos de commit
+- ✅ Longitud apropiada del título
+
 ## Requisitos para Merge
 
 Todos los checks deben pasar antes de hacer merge:
 - ✅ Code Quality Check exitoso
 - ✅ Django Tests exitoso
+- ✅ PR Title Validation exitoso
 - ✅ Review aprobado (si es requerido)
 
 ## Semantic Release
 
 Una vez que el PR se mergea a `main`:
-- 🚀 Semantic-release ejecuta automáticamente
+- 🚀 Semantic-release ejecuta automáticamente basado en el título del PR
 - 📝 Genera CHANGELOG.md automáticamente
 - 🏷️ Crea tags de versión automáticamente
 - 📦 Actualiza la versión en `pyproject.toml`
@@ -75,7 +124,6 @@ poetry run ruff format --check .
 
 # Verificar Django
 poetry run python src/manage.py check
-poetry run python src/manage.py check --deploy
 
 # Ejecutar tests
 poetry run python src/manage.py test


### PR DESCRIPTION
- Add pr-title-check.yml workflow using amannn/action-semantic-pull-request
- Add pr-title-validation.yml workflow with custom regex validation
- Both workflows validate PR titles follow conventional commit format
- Add automatic comment on invalid PR titles with helpful examples
- Update CONTRIBUTING.md with detailed PR title format rules
- Update PR template to highlight title format requirements
- Ensure semantic-release works correctly with standardized PR titles