### PR TITLE
fix: remove npm cache from release workflow to resolve lock file error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
-        cache: 'npm'
 
     - name: Install semantic-release and plugins
       run: npm install


### PR DESCRIPTION
- Remove cache: 'npm' from setup-node action
- npm caching requires lock files that don't exist in Python projects
- Semantic-release dependencies will install fresh each time
- Fixes error: Dependencies lock file is not found

## Description

Brief description of the changes made.

## ⚠️ Check PR Title

**IMPORTANT**: This PR title must follow the conventional commits format:
- ✅ Format: `type(scope): description`
- ✅ Valid examples: `feat: add user auth`, `fix(api): resolve bug`, `docs: update readme`
- ❌ NOT valid: `Add feature`, `Fix bug`, `Update`

## Type of change

- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (change that may break existing functionality)
- [ ] Refactoring (code change that neither fixes bugs nor adds functionality)
- [ ] Documentation
- [ ] Configuration/CI

## How has this been tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] `python src/manage.py check` passes without errors
- [ ] `ruff check .` passes without errors

## Checklist

- [ ] **My PR title follows the conventional commits format**
- [ ] My code follows the project conventions (Ruff)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have updated documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my functionality
- [ ] New and existing tests pass locally

## Additional context

Add any additional context about the PR here.
